### PR TITLE
adjust namespace on uris

### DIFF
--- a/models/OakD-Lite/model.sdf
+++ b/models/OakD-Lite/model.sdf
@@ -22,7 +22,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://OakD-Lite/meshes/OakDLite.dae</uri>
+            <uri>model://models/OakD-Lite/meshes/OakDLite.dae</uri>
           </mesh>
         </geometry>
       </visual>

--- a/models/advanced_plane/model.sdf
+++ b/models/advanced_plane/model.sdf
@@ -40,7 +40,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/body.dae</uri>
+            <uri>model://models/rc_cessna/meshes/body.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -104,7 +104,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://rc_cessna/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/rc_cessna/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -151,7 +151,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/left_aileron.dae</uri>
+            <uri>model://models/rc_cessna/meshes/left_aileron.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -178,7 +178,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/right_aileron.dae</uri>
+            <uri>model://models/rc_cessna/meshes/right_aileron.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -205,7 +205,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/left_flap.dae</uri>
+            <uri>model://models/rc_cessna/meshes/left_flap.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -232,7 +232,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/right_flap.dae</uri>
+            <uri>model://models/rc_cessna/meshes/right_flap.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -259,7 +259,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/elevators.dae</uri>
+            <uri>model://models/rc_cessna/meshes/elevators.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -286,7 +286,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/rudder.dae</uri>
+            <uri>model://models/rc_cessna/meshes/rudder.dae</uri>
           </mesh>
         </geometry>
         <material>

--- a/models/omnicopter/model.sdf
+++ b/models/omnicopter/model.sdf
@@ -41,7 +41,7 @@
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
-            <uri>model://omnicopter/meshes/omnicopter.stl</uri>
+            <uri>model://models/omnicopter/meshes/omnicopter.stl</uri>
           </mesh>
         </geometry>
         <material>
@@ -106,7 +106,7 @@
         <geometry>
           <mesh>
             <scale>0.5 0.5 0.5</scale>
-            <uri>model://omnicopter/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/omnicopter/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -171,7 +171,7 @@
         <geometry>
           <mesh>
             <scale>0.5 0.5 0.5</scale>
-            <uri>model://omnicopter/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/omnicopter/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -235,7 +235,7 @@
         <geometry>
           <mesh>
             <scale>0.5 0.5 0.5</scale>
-            <uri>model://omnicopter/meshes/iris_prop_cw.dae</uri>
+            <uri>model://models/omnicopter/meshes/iris_prop_cw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -300,7 +300,7 @@
         <geometry>
           <mesh>
             <scale>0.5 0.5 0.5</scale>
-            <uri>model://omnicopter/meshes/iris_prop_cw.dae</uri>
+            <uri>model://models/omnicopter/meshes/iris_prop_cw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -365,7 +365,7 @@
         <geometry>
           <mesh>
             <scale>0.5 0.5 0.5</scale>
-            <uri>model://omnicopter/meshes/iris_prop_cw.dae</uri>
+            <uri>model://models/omnicopter/meshes/iris_prop_cw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -430,7 +430,7 @@
         <geometry>
           <mesh>
             <scale>0.5 0.5 0.5</scale>
-            <uri>model://omnicopter/meshes/iris_prop_cw.dae</uri>
+            <uri>model://models/omnicopter/meshes/iris_prop_cw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -495,7 +495,7 @@
         <geometry>
           <mesh>
             <scale>0.5 0.5 0.5</scale>
-            <uri>model://omnicopter/meshes/iris_prop_cw.dae</uri>
+            <uri>model://models/omnicopter/meshes/iris_prop_cw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -559,7 +559,7 @@
         <geometry>
           <mesh>
             <scale>0.5 0.5 0.5</scale>
-            <uri>model://omnicopter/meshes/iris_prop_cw.dae</uri>
+            <uri>model://models/omnicopter/meshes/iris_prop_cw.dae</uri>
           </mesh>
         </geometry>
         <material>

--- a/models/px4vision/model.sdf
+++ b/models/px4vision/model.sdf
@@ -44,7 +44,7 @@
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
-            <uri>model://px4vision/meshes/body.dae</uri>
+            <uri>model://models/px4vision/meshes/body.dae</uri>
           </mesh>
         </geometry>
         <material> <!-- DarkGrey-->
@@ -108,7 +108,7 @@
         <geometry>
           <mesh>
             <scale>0.6 0.6 0.6</scale>
-            <uri>model://px4vision/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/px4vision/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material> <!-- Blue -->
@@ -172,7 +172,7 @@
         <geometry>
           <mesh>
             <scale>0.6 0.6 0.6</scale>
-            <uri>model://px4vision/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/px4vision/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material> <!-- DarkGrey -->
@@ -236,7 +236,7 @@
         <geometry>
           <mesh>
             <scale>0.6 0.6 0.6</scale>
-            <uri>model://px4vision/meshes/iris_prop_cw.dae</uri>
+            <uri>model://models/px4vision/meshes/iris_prop_cw.dae</uri>
           </mesh>
         </geometry>
         <material> <!-- Blue -->
@@ -300,7 +300,7 @@
         <geometry>
           <mesh>
             <scale>0.6 0.6 0.6</scale>
-            <uri>model://px4vision/meshes/iris_prop_cw.dae</uri>
+            <uri>model://models/px4vision/meshes/iris_prop_cw.dae</uri>
           </mesh>
         </geometry>
         <material> <!-- DarkGrey -->

--- a/models/rc_cessna/model.sdf
+++ b/models/rc_cessna/model.sdf
@@ -69,7 +69,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/body.dae</uri>
+            <uri>model://models/rc_cessna/meshes/body.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -184,7 +184,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://rc_cessna/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/rc_cessna/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -229,7 +229,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/left_aileron.dae</uri>
+            <uri>model://models/rc_cessna/meshes/left_aileron.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -385,7 +385,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/right_aileron.dae</uri>
+            <uri>model://models/rc_cessna/meshes/right_aileron.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -412,7 +412,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/left_flap.dae</uri>
+            <uri>model://models/rc_cessna/meshes/left_flap.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -439,7 +439,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/right_flap.dae</uri>
+            <uri>model://models/rc_cessna/meshes/right_flap.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -466,7 +466,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/elevators.dae</uri>
+            <uri>model://models/rc_cessna/meshes/elevators.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -493,7 +493,7 @@
         <geometry>
           <mesh>
             <scale>0.1 0.1 0.1</scale>
-            <uri>model://rc_cessna/meshes/rudder.dae</uri>
+            <uri>model://models/rc_cessna/meshes/rudder.dae</uri>
           </mesh>
         </geometry>
         <material>

--- a/models/standard_vtol/model.sdf
+++ b/models/standard_vtol/model.sdf
@@ -43,7 +43,7 @@
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
-            <uri>model://standard_vtol/meshes/x8_wing.dae</uri>
+            <uri>model://models/standard_vtol/meshes/x8_wing.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -183,7 +183,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://standard_vtol/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/standard_vtol/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -246,7 +246,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://standard_vtol/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/standard_vtol/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -309,7 +309,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://standard_vtol/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/standard_vtol/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -372,7 +372,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://standard_vtol/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/standard_vtol/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -436,7 +436,7 @@
         <geometry>
           <mesh>
             <scale>0.8 0.8 0.8</scale>
-            <uri>model://standard_vtol/meshes/iris_prop_ccw.dae</uri>
+            <uri>model://models/standard_vtol/meshes/iris_prop_ccw.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -483,7 +483,7 @@
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
-            <uri>model://standard_vtol/meshes/x8_elevon_left.dae</uri>
+            <uri>model://models/standard_vtol/meshes/x8_elevon_left.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -510,7 +510,7 @@
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
-            <uri>model://standard_vtol/meshes/x8_elevon_right.dae</uri>
+            <uri>model://models/standard_vtol/meshes/x8_elevon_right.dae</uri>
           </mesh>
         </geometry>
         <material>

--- a/models/x500/model.sdf
+++ b/models/x500/model.sdf
@@ -2,7 +2,7 @@
 <sdf version='1.9'>
   <model name='x500'>
     <include merge='true'>
-      <uri>model://x500_base</uri>
+      <uri>model://models/x500_base</uri>
     </include>
     <plugin filename="gz-sim-multicopter-motor-model-system" name="gz::sim::systems::MulticopterMotorModel">
       <jointName>rotor_0_joint</jointName>

--- a/models/x500_base/model.sdf
+++ b/models/x500_base/model.sdf
@@ -23,7 +23,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://x500_base/meshes/NXP-HGD-CF.dae</uri>
+            <uri>model://models/x500_base/meshes/NXP-HGD-CF.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -32,7 +32,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://x500_base/meshes/5010Base.dae</uri>
+            <uri>model://models/x500_base/meshes/5010Base.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -41,7 +41,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://x500_base/meshes/5010Base.dae</uri>
+            <uri>model://models/x500_base/meshes/5010Base.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -50,7 +50,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://x500_base/meshes/5010Base.dae</uri>
+            <uri>model://models/x500_base/meshes/5010Base.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -59,7 +59,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://x500_base/meshes/5010Base.dae</uri>
+            <uri>model://models/x500_base/meshes/5010Base.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -77,7 +77,7 @@
           <specular>1.0 1.0 1.0</specular>
           <pbr>
             <metal>
-              <albedo_map>model://x500_base/materials/textures/nxp.png</albedo_map>
+              <albedo_map>model://models/x500_base/materials/textures/nxp.png</albedo_map>
             </metal>
           </pbr>
         </material>
@@ -96,7 +96,7 @@
           <specular>1.0 1.0 1.0</specular>
           <pbr>
             <metal>
-              <albedo_map>model://x500_base/materials/textures/nxp.png</albedo_map>
+              <albedo_map>model://models/x500_base/materials/textures/nxp.png</albedo_map>
             </metal>
           </pbr>
         </material>
@@ -115,7 +115,7 @@
           <specular>1.0 1.0 1.0</specular>
           <pbr>
             <metal>
-              <albedo_map>model://x500_base/materials/textures/rd.png</albedo_map>
+              <albedo_map>model://models/x500_base/materials/textures/rd.png</albedo_map>
             </metal>
           </pbr>
         </material>
@@ -250,7 +250,7 @@
         <geometry>
           <mesh>
             <scale>0.8461538461538461 0.8461538461538461 0.8461538461538461</scale>
-            <uri>model://x500_base/meshes/1345_prop_ccw.stl</uri>
+            <uri>model://models/x500_base/meshes/1345_prop_ccw.stl</uri>
           </mesh>
         </geometry>
         <material>
@@ -265,7 +265,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://x500_base/meshes/5010Bell.dae</uri>
+            <uri>model://models/x500_base/meshes/5010Bell.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -322,7 +322,7 @@
         <geometry>
           <mesh>
             <scale>0.8461538461538461 0.8461538461538461 0.8461538461538461</scale>
-            <uri>model://x500_base/meshes/1345_prop_ccw.stl</uri>
+            <uri>model://models/x500_base/meshes/1345_prop_ccw.stl</uri>
           </mesh>
         </geometry>
         <material>
@@ -337,7 +337,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://x500_base/meshes/5010Bell.dae</uri>
+            <uri>model://models/x500_base/meshes/5010Bell.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -394,7 +394,7 @@
         <geometry>
           <mesh>
             <scale>0.8461538461538461 0.8461538461538461 0.8461538461538461</scale>
-            <uri>model://x500_base/meshes/1345_prop_cw.stl</uri>
+            <uri>model://models/x500_base/meshes/1345_prop_cw.stl</uri>
           </mesh>
         </geometry>
         <material>
@@ -409,7 +409,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://x500_base/meshes/5010Bell.dae</uri>
+            <uri>model://models/x500_base/meshes/5010Bell.dae</uri>
           </mesh>
         </geometry>
       </visual>
@@ -466,7 +466,7 @@
         <geometry>
           <mesh>
             <scale>0.8461538461538461 0.8461538461538461 0.8461538461538461</scale>
-            <uri>model://x500_base/meshes/1345_prop_cw.stl</uri>
+            <uri>model://models/x500_base/meshes/1345_prop_cw.stl</uri>
           </mesh>
         </geometry>
         <material>
@@ -481,7 +481,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://x500_base/meshes/5010Bell.dae</uri>
+            <uri>model://models/x500_base/meshes/5010Bell.dae</uri>
           </mesh>
         </geometry>
       </visual>

--- a/models/x500_depth/model.sdf
+++ b/models/x500_depth/model.sdf
@@ -5,7 +5,7 @@
       <uri>x500</uri>
     </include>
     <include merge='true'>
-      <uri>model://OakD-Lite</uri>
+      <uri>model://models/OakD-Lite</uri>
       <pose>.12 .03 .242 0 0 0</pose>
     </include>
     <joint name="CameraJoint" type="fixed">


### PR DESCRIPTION
`model://` in general gets substituted with the `GZ_SIM_RESOURCE_PATH`. As we are now looking to also resolve worlds with the resource path, it becomes necessary to adjust uri's to include `/models/` in model sdf files.