### PR TITLE
increase monocam clipping distance

### DIFF
--- a/models/mono_cam/model.sdf
+++ b/models/mono_cam/model.sdf
@@ -27,7 +27,7 @@
           </image>
           <clip>
             <near>0.1</near>
-            <far>100</far>
+            <far>3000</far>
           </clip>
         </camera>
         <always_on>1</always_on>


### PR DESCRIPTION
Increase the monocam clipping distance to remove the cropping effect seen in video stream. 