### PR TITLE
Fix altitude to elevation

### DIFF
--- a/worlds/baylands.sdf
+++ b/worlds/baylands.sdf
@@ -113,6 +113,7 @@
       <world_frame_orientation>ENU</world_frame_orientation>
       <latitude_deg>37.412173071650805</latitude_deg>
       <longitude_deg>-121.998878727967</longitude_deg>
+      <elevation>38</elevation>
     </spherical_coordinates>
   </world>
 </sdf>

--- a/worlds/default.sdf
+++ b/worlds/default.sdf
@@ -150,7 +150,7 @@
       <world_frame_orientation>ENU</world_frame_orientation>
       <latitude_deg>47.397971057728974</latitude_deg>
       <longitude_deg> 8.546163739800146</longitude_deg>
-      <altitude>0</altitude>
+      <elevation>0</elevation>
     </spherical_coordinates>
   </world>
 </sdf>

--- a/worlds/windy.sdf
+++ b/worlds/windy.sdf
@@ -153,7 +153,7 @@
       <world_frame_orientation>ENU</world_frame_orientation>
       <latitude_deg>47.397971057728974</latitude_deg>
       <longitude_deg> 8.546163739800146</longitude_deg>
-      <altitude>0</altitude>
+      <elevation>0</elevation>
     </spherical_coordinates>
   </world>
 </sdf>


### PR DESCRIPTION
As mentioned in issue #31, the word altitude is not correct and should be replaced by the word elevation.
For baylands, the elevation was taken as the real-life location of the park in Sunnyvale, CA, which has an elevation of 38 metres above sea level. https://en.wikipedia.org/wiki/Sunnyvale,_California