### PR TITLE
Added IMU sensor noise to the model, to avoid STALE messages

### DIFF
--- a/models/lawnmower/model.sdf
+++ b/models/lawnmower/model.sdf
@@ -221,6 +221,60 @@
       <sensor name="imu_sensor" type="imu">
         <always_on>1</always_on>
         <update_rate>250</update_rate>
+        <imu>
+          <angular_velocity>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.0003394</stddev>
+                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.0003394</stddev>
+                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.0003394</stddev>
+                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+              </noise>
+            </z>
+          </angular_velocity>
+          <linear_acceleration>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.004</stddev>
+                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.004</stddev>
+                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.004</stddev>
+                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+              </noise>
+            </z>
+          </linear_acceleration>
+        </imu>
       </sensor>
     </link>
     <!-- Wheels -->


### PR DESCRIPTION
This is direct following of the https://github.com/PX4/PX4-gazebo-models/pull/33

@PerFrivik @frede791 @dagar   I don't see a reason for the lawnmower IMU to be different from R1 Rover settings, so I just copied those.

Maybe, vibrations from the gas engine could be accounted in the future revisions. I am not good with these numbers, any clues?

I'd be more interested in adding better precision to NavSat sensor, emulating RTK 1.5 cm accuracy. Any suggestions?

BTW, if anybody is still interested in "_two space indentation/tabs for SDF_" - I can fix it here for all models, I have a tool (XML Copy Editor https://sourceforge.net/projects/xml-copy-editor/  - it does "_XML->pretty print_" very well). ;-)  - @bperseghetti 
