### PR TITLE
Improved default.sdf world to have sky and grassy ground plane

### DIFF
--- a/worlds/default.sdf
+++ b/worlds/default.sdf
@@ -1,27 +1,28 @@
-<sdf version='1.9'>
-  <world name='default'>
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<sdf version="1.9">
+  <world name="default">
     <physics type="ode">
       <max_step_size>0.004</max_step_size>
       <real_time_factor>1.0</real_time_factor>
       <real_time_update_rate>250</real_time_update_rate>
     </physics>
-    <plugin name='gz::sim::systems::Physics' filename='gz-sim-physics-system'/>
-    <plugin name='gz::sim::systems::UserCommands' filename='gz-sim-user-commands-system'/>
-    <plugin name='gz::sim::systems::SceneBroadcaster' filename='gz-sim-scene-broadcaster-system'/>
-    <plugin name='gz::sim::systems::Contact' filename='gz-sim-contact-system'/>
-    <plugin name='gz::sim::systems::Imu' filename='gz-sim-imu-system'/>
-    <plugin name='gz::sim::systems::AirPressure' filename='gz-sim-air-pressure-system'/>
-    <plugin name='gz::sim::systems::ApplyLinkWrench' filename='gz-sim-apply-link-wrench-system'/>
-    <plugin name='gz::sim::systems::NavSat' filename='gz-sim-navsat-system'/>
-    <plugin name='gz::sim::systems::Sensors' filename='gz-sim-sensors-system'>
+    <plugin name="gz::sim::systems::Physics" filename="gz-sim-physics-system"/>
+    <plugin name="gz::sim::systems::UserCommands" filename="gz-sim-user-commands-system"/>
+    <plugin name="gz::sim::systems::SceneBroadcaster" filename="gz-sim-scene-broadcaster-system"/>
+    <plugin name="gz::sim::systems::Contact" filename="gz-sim-contact-system"/>
+    <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system"/>
+    <plugin name="gz::sim::systems::AirPressure" filename="gz-sim-air-pressure-system"/>
+    <plugin name="gz::sim::systems::ApplyLinkWrench" filename="gz-sim-apply-link-wrench-system"/>
+    <plugin name="gz::sim::systems::NavSat" filename="gz-sim-navsat-system"/>
+    <plugin name="gz::sim::systems::Sensors" filename="gz-sim-sensors-system">
       <render_engine>ogre2</render_engine>
     </plugin>
-    <gui fullscreen='false'>
-      <plugin name='3D View' filename='GzScene3D'>
+    <gui fullscreen="false">
+      <plugin name="3D View" filename="GzScene3D">
         <gz-gui>
           <title>3D View</title>
-          <property type='bool' key='showTitleBar'>0</property>
-          <property type='string' key='state'>docked</property>
+          <property type="bool" key="showTitleBar">0</property>
+          <property type="string" key="state">docked</property>
         </gz-gui>
         <engine>ogre2</engine>
         <scene>scene</scene>
@@ -29,36 +30,36 @@
         <background_color>0.8984631152222222 0.8984631152222222 0.8984631152222222</background_color>
         <camera_pose>-6 0 6 0 0.5 0</camera_pose>
       </plugin>
-      <plugin name='World control' filename='WorldControl'>
+      <plugin name="World control" filename="WorldControl">
         <gz-gui>
           <title>World control</title>
-          <property type='bool' key='showTitleBar'>0</property>
-          <property type='bool' key='resizable'>0</property>
-          <property type='double' key='height'>72</property>
-          <property type='double' key='width'>121</property>
-          <property type='double' key='z'>1</property>
-          <property type='string' key='state'>floating</property>
-          <anchors target='3D View'>
-            <line own='left' target='left'/>
-            <line own='bottom' target='bottom'/>
+          <property type="bool" key="showTitleBar">0</property>
+          <property type="bool" key="resizable">0</property>
+          <property type="double" key="height">72</property>
+          <property type="double" key="width">121</property>
+          <property type="double" key="z">1</property>
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
           </anchors>
         </gz-gui>
         <play_pause>1</play_pause>
         <step>1</step>
         <start_paused>1</start_paused>
       </plugin>
-      <plugin name='World stats' filename='WorldStats'>
+      <plugin name="World stats" filename="WorldStats">
         <gz-gui>
           <title>World stats</title>
-          <property type='bool' key='showTitleBar'>0</property>
-          <property type='bool' key='resizable'>0</property>
-          <property type='double' key='height'>110</property>
-          <property type='double' key='width'>290</property>
-          <property type='double' key='z'>1</property>
-          <property type='string' key='state'>floating</property>
-          <anchors target='3D View'>
-            <line own='right' target='right'/>
-            <line own='bottom' target='bottom'/>
+          <property type="bool" key="showTitleBar">0</property>
+          <property type="bool" key="resizable">0</property>
+          <property type="double" key="height">110</property>
+          <property type="double" key="width">290</property>
+          <property type="double" key="z">1</property>
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="bottom" target="bottom"/>
           </anchors>
         </gz-gui>
         <sim_time>1</sim_time>
@@ -66,21 +67,26 @@
         <real_time_factor>1</real_time_factor>
         <iterations>1</iterations>
       </plugin>
-      <plugin name='Entity tree' filename='EntityTree'/>
+      <plugin name="Entity tree" filename="EntityTree"/>
     </gui>
     <gravity>0 0 -9.8</gravity>
     <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
-    <atmosphere type='adiabatic'/>
+    <atmosphere type="adiabatic"/>
     <scene>
-      <grid>false</grid>
-      <ambient>0.4 0.4 0.4 1</ambient>
-      <background>0.7 0.7 0.7 1</background>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
+      <grid>true</grid>
+      <ambient>0.5 0.5 0.5 0.3</ambient>
+      <background>0.3 0.3 0.3 0.3</background>
       <shadows>true</shadows>
     </scene>
-    <model name='ground_plane'>
+    <model name="ground_plane">
       <static>true</static>
-      <link name='link'>
-        <collision name='collision'>
+      <link name="link">
+        <collision name="collision">
           <geometry>
             <plane>
               <normal>0 0 1</normal>
@@ -89,23 +95,33 @@
           </geometry>
           <surface>
             <friction>
-              <ode/>
+              <ode>
+                <mu>0.6</mu>
+                <mu2>0.6</mu2>
+              </ode>
             </friction>
             <bounce/>
-            <contact/>
+            <contact>
+              <collide_bitmask>65535</collide_bitmask>
+              <ode>
+                <min_depth>0.005</min_depth>
+                <kp>1e8</kp>
+              </ode>
+            </contact>
           </surface>
         </collision>
-        <visual name='visual'>
+        <visual name="visual">
+          <cast_shadows>false</cast_shadows>
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>100 100</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <material>
-            <ambient>0.8 0.8 0.8 1</ambient>
-            <diffuse>0.8 0.8 0.8 1</diffuse>
-            <specular>0.8 0.8 0.8 1</specular>
+            <diffuse>0.6 1.0 0.25 0.5</diffuse>
+            <specular>0 0 0 0</specular>
+            <emissive>0 0 0 0</emissive>
           </material>
         </visual>
         <pose>0 0 0 0 -0 0</pose>
@@ -126,7 +142,7 @@
       <pose>0 0 0 0 -0 0</pose>
       <self_collide>false</self_collide>
     </model>
-    <light name='sunUTC' type='directional'>
+    <light name="sunUTC" type="directional">
       <pose>0 0 500 0 -0 0</pose>
       <cast_shadows>true</cast_shadows>
       <intensity>1</intensity>
@@ -145,13 +161,25 @@
         <falloff>0</falloff>
       </spot>
     </light>
+    <light type="directional" name="sun_2">
+      <cast_shadows>true</cast_shadows>
+      <pose>2 2 2 0 0 0</pose>
+      <diffuse>0.5 0.5 0.5 0.3</diffuse>
+      <specular>0.2 0.2 0.2 0.3</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>0.01 0.01 -0.9</direction>
+    </light>
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>
       <world_frame_orientation>ENU</world_frame_orientation>
       <latitude_deg>47.397971057728974</latitude_deg>
       <longitude_deg> 8.546163739800146</longitude_deg>
-      <altitude>0</altitude>
+      <elevation>0</elevation>
     </spherical_coordinates>
   </world>
 </sdf>
-


### PR DESCRIPTION
This is a modified _default.sdf_ world file - I added sky, some lightning, grid and painted the ground plane grassy green.

I also added some friction/collision properties to the best of my knowledge.

I used "_XML Copy Editor_" to "pretty-print" the resulting SDF file - it fixes spaces and replaces single quotes with doubles.

<img width="891" alt="image" src="https://github.com/PX4/PX4-gazebo-models/assets/16037285/313a4999-6136-44d5-b471-851ab59d2977">

