### PR TITLE
Add X500 with downward monocular camera

### DIFF
--- a/models/mono_cam/model.sdf
+++ b/models/mono_cam/model.sdf
@@ -17,6 +17,36 @@
           <izz>0.00004</izz>
         </inertia>
       </inertial>
+      <visual name="mono_cam/visual/housing">
+        <geometry>
+          <box>
+            <size>0.02 0.04 0.04</size>
+          </box>
+        </geometry>
+      </visual>
+      <visual name="mono_cam/visual/lens">
+        <pose>0.015 0 0 0 1.5707 0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.008</radius>
+            <length>0.01</length>
+          </cylinder>
+        </geometry>
+      </visual>
+      <visual name="mono_cam/visual/lens_glass">
+        <pose>0.014 0 0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.0079</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <ambient>.4 .4 .5 .95</ambient>
+          <diffuse>.4 .4 .5 .95</diffuse>
+          <specular>1 1 1 1</specular>
+          <emissive>0 0 0 1</emissive>
+        </material>
+      </visual>
       <sensor name="imager" type="camera">
         <pose>0 0 0 0 0 0</pose>
         <camera>

--- a/models/x500_mono_cam_down/model.config
+++ b/models/x500_mono_cam_down/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<model>
+  <name>x500_mono_cam_down</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+  <author>
+    <name>Daniel Mesham</name>
+    <email>daniel@auterion.com</email>
+  </author>
+  <description>An X500 with a downward-facing monocular camera.</description>
+</model>

--- a/models/x500_mono_cam_down/model.sdf
+++ b/models/x500_mono_cam_down/model.sdf
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sdf version='1.9'>
+  <model name='x500_mono_cam_down'>
+    <include merge='true'>
+      <uri>x500</uri>
+    </include>
+    <include merge='true'>
+      <uri>model://mono_cam</uri>
+      <pose>.13 0 .12 0 1.5707 0</pose>
+    </include>
+    <joint name="CameraJoint" type="fixed">
+      <parent>base_link</parent>
+      <child>mono_cam/base_link</child>
+      <pose relative_to="base_link">.13 0 .12 0 1.5707 0</pose>
+    </joint>
+
+    <link name="camera_connector_arm">
+      <visual name="camera_connector_arm_visual">
+        <pose>.13 0 .185 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.01 0.01 0.11</size>
+          </box>
+        </geometry>
+        <material>
+          <script>
+            <name>Gazebo/Grey</name>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <joint name="camera_connector_arm_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>camera_connector_arm</child>
+      <pose relative_to="base_link">.13 0 .185 0 0 0</pose>
+    </joint>
+  </model>
+</sdf>


### PR DESCRIPTION
- Add visuals for the monocular camera.
- Create an X500 model with the monocular camera facing down.

Follow-up PRs:
- [ ] PX4 (airframe & SITL build target)
- [ ] Docs

![mono_cam_down_1](https://github.com/PX4/PX4-gazebo-models/assets/12900114/eeb9b60c-8e75-45e1-990b-525b33a59aaf)
![mono_cam_down_2](https://github.com/PX4/PX4-gazebo-models/assets/12900114/aa90018b-c0c3-4ea6-b9cd-6b0f85e7ea73)
