### PR TITLE
Add lidar altimeter sensors

### DIFF
--- a/models/advanced_plane/model.sdf
+++ b/models/advanced_plane/model.sdf
@@ -125,6 +125,36 @@
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>
+      <sensor name="distance_sensor" type="gpu_lidar">
+        <pose>0 0 -0.1 0 1.57 0</pose>
+        <always_on>1</always_on>
+        <update_rate>25</update_rate>
+        <lidar>
+          <scan>
+            <horizontal>
+              <samples>1</samples>
+              <resolution>1</resolution>
+              <min_angle>0</min_angle>
+              <max_angle>0</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>1</samples>
+              <resolution>1</resolution>
+              <min_angle>0</min_angle>
+              <max_angle>0</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.05</min>
+            <max>40.0</max>
+            <resolution>0.05</resolution>
+          </range>
+          <noise>
+            <mean>0</mean>
+            <stddev>0.025</stddev>
+          </noise>
+        </lidar>
+      </sensor>
     </link>
     <link name='rotor_puller'>
       <pose>0.3 0 0.0 0 1.57 0</pose>

--- a/models/rc_cessna/model.sdf
+++ b/models/rc_cessna/model.sdf
@@ -154,6 +154,36 @@
           </pressure>
         </air_pressure>
       </sensor>
+      <sensor name="distance_sensor" type="gpu_lidar">
+        <pose>0 0 -0.1 0 1.57 0</pose>
+        <always_on>1</always_on>
+        <update_rate>25</update_rate>
+        <lidar>
+          <scan>
+            <horizontal>
+              <samples>1</samples>
+              <resolution>1</resolution>
+              <min_angle>0</min_angle>
+              <max_angle>0</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>1</samples>
+              <resolution>1</resolution>
+              <min_angle>0</min_angle>
+              <max_angle>0</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.05</min>
+            <max>40.0</max>
+            <resolution>0.05</resolution>
+          </range>
+          <noise>
+            <mean>0</mean>
+            <stddev>0.025</stddev>
+          </noise>
+        </lidar>
+      </sensor>
     </link>
     <link name="airspeed">
       <pose>0 0 0 0 0 0</pose>

--- a/worlds/aruco.sdf
+++ b/worlds/aruco.sdf
@@ -170,7 +170,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>1 1</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <surface>
@@ -185,7 +185,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>100 100</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <material>

--- a/worlds/default.sdf
+++ b/worlds/default.sdf
@@ -170,7 +170,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>1 1</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <surface>
@@ -185,7 +185,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>100 100</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <material>

--- a/worlds/lawn.sdf
+++ b/worlds/lawn.sdf
@@ -175,7 +175,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>1 1</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <surface>

--- a/worlds/rover.sdf
+++ b/worlds/rover.sdf
@@ -170,7 +170,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>1 1</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <surface>

--- a/worlds/walls.sdf
+++ b/worlds/walls.sdf
@@ -182,7 +182,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>1 1</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <surface>
@@ -197,7 +197,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>100 100</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <material>

--- a/worlds/windy.sdf
+++ b/worlds/windy.sdf
@@ -17,7 +17,6 @@
       <render_engine>ogre2</render_engine>
     </plugin>
     <gui fullscreen='false'>
-      
       <!-- 3D scene -->
       <plugin filename="MinimalScene" name="3D View">
         <gz-gui>
@@ -117,7 +116,6 @@
           <property key="showTitleBar" type="bool">false</property>
         </gz-gui>
       </plugin>
-      
       <plugin name='World control' filename='WorldControl'>
         <gz-gui>
           <title>World control</title>
@@ -173,7 +171,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>1 1</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <surface>
@@ -188,7 +186,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>100 100</size>
+              <size>400 400</size>
             </plane>
           </geometry>
           <material>


### PR DESCRIPTION
Add lidar sensor to rc_cessna and advanced_plane models. This will read out the altitude above ground (AGL). It only works if there is an actual object below. Therefore the world base plates are also enlarged.

Link to the main PR: https://github.com/PX4/PX4-Autopilot/pull/23755