### PR TITLE
rc_cessna: increase drag and reduce motor torque

### DIFF
--- a/models/rc_cessna/model.sdf
+++ b/models/rc_cessna/model.sdf
@@ -732,7 +732,7 @@
     <plugin filename="gz-sim-lift-drag-system" name="gz::sim::systems::LiftDrag">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
-      <cda>0.6417112299</cda>
+      <cda>1.5</cda>
       <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
@@ -756,7 +756,7 @@
     <plugin filename="gz-sim-lift-drag-system" name="gz::sim::systems::LiftDrag">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
-      <cda>0.6417112299</cda>
+      <cda>1.5</cda>
       <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
@@ -847,7 +847,7 @@
       <cda_stall>-0.9233984055</cda_stall>
       <cma_stall>0</cma_stall>
       <cp>-0.5 0 0.05</cp>
-      <area>0.02</area>
+      <area>0.1</area>
       <air_density>1.2041</air_density>
       <forward>1 0 0</forward>
       <upward>0 1 0</upward>
@@ -868,7 +868,7 @@
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1000</maxRotVelocity>
-      <motorConstant>2.44858e-05</motorConstant>
+      <motorConstant>.9e-05</motorConstant>
       <momentConstant>0.016</momentConstant>
       <commandSubTopic>command/motor_speed</commandSubTopic>
       <motorNumber>0</motorNumber>

--- a/models/rc_cessna/model.sdf
+++ b/models/rc_cessna/model.sdf
@@ -692,6 +692,7 @@
           <upper>1.79769e+308</upper>
         </limit>
         <dynamics>
+          <friction>0.02</friction>
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
@@ -708,6 +709,7 @@
           <upper>1.79769e+308</upper>
         </limit>
         <dynamics>
+          <friction>0.02</friction>
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
@@ -724,6 +726,7 @@
           <upper>1.79769e+308</upper>
         </limit>
         <dynamics>
+          <friction>0.02</friction>
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
@@ -868,7 +871,7 @@
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1000</maxRotVelocity>
-      <motorConstant>.9e-05</motorConstant>
+      <motorConstant>1.2e-05</motorConstant>
       <momentConstant>0.016</momentConstant>
       <commandSubTopic>command/motor_speed</commandSubTopic>
       <motorNumber>0</motorNumber>


### PR DESCRIPTION
Improved rc_cessna model simulation behaviour:
- increased wings drag for faster deceleration when there is no throttle
- increased vertical stabilizer area for a more realistic air resistance during banking manouvers
- decreased motor power to reduce the plane top speed at full throttle (from over 100m/s to a more reasonable 40-50m/s)