### PR TITLE
Wrong display of the WroldControl buttons

### DIFF
--- a/worlds/aruco.sdf
+++ b/worlds/aruco.sdf
@@ -121,7 +121,7 @@
           <property type="bool" key="showTitleBar">0</property>
           <property type="bool" key="resizable">0</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
+          <property type="double" key="width">145</property>
           <property type="double" key="z">1</property>
           <property type="string" key="state">floating</property>
           <anchors target="3D View">

--- a/worlds/baylands.sdf
+++ b/worlds/baylands.sdf
@@ -124,7 +124,7 @@
           <property type='bool' key='showTitleBar'>0</property>
           <property type='bool' key='resizable'>0</property>
           <property type='double' key='height'>72</property>
-          <property type='double' key='width'>121</property>
+          <property type='double' key='width'>145</property>
           <property type='double' key='z'>1</property>
           <property type='string' key='state'>floating</property>
           <anchors target='3D View'>

--- a/worlds/default.sdf
+++ b/worlds/default.sdf
@@ -122,7 +122,7 @@
           <property type="bool" key="showTitleBar">0</property>
           <property type="bool" key="resizable">0</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
+          <property type="double" key="width">145</property>
           <property type="double" key="z">1</property>
           <property type="string" key="state">floating</property>
           <anchors target="3D View">

--- a/worlds/lawn.sdf
+++ b/worlds/lawn.sdf
@@ -121,7 +121,7 @@
           <property type="bool" key="showTitleBar">0</property>
           <property type="bool" key="resizable">0</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
+          <property type="double" key="width">145</property>
           <property type="double" key="z">1</property>
           <property type="string" key="state">floating</property>
           <anchors target="3D View">

--- a/worlds/rover.sdf
+++ b/worlds/rover.sdf
@@ -121,7 +121,7 @@
           <property type="bool" key="showTitleBar">0</property>
           <property type="bool" key="resizable">0</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
+          <property type="double" key="width">145</property>
           <property type="double" key="z">1</property>
           <property type="string" key="state">floating</property>
           <anchors target="3D View">

--- a/worlds/walls.sdf
+++ b/worlds/walls.sdf
@@ -121,7 +121,7 @@
           <property type="bool" key="showTitleBar">0</property>
           <property type="bool" key="resizable">0</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
+          <property type="double" key="width">145</property>
           <property type="double" key="z">1</property>
           <property type="string" key="state">floating</property>
           <anchors target="3D View">

--- a/worlds/windy.sdf
+++ b/worlds/windy.sdf
@@ -124,7 +124,7 @@
           <property type='bool' key='showTitleBar'>0</property>
           <property type='bool' key='resizable'>0</property>
           <property type='double' key='height'>72</property>
-          <property type='double' key='width'>121</property>
+          <property type='double' key='width'>145</property>
           <property type='double' key='z'>1</property>
           <property type='string' key='state'>floating</property>
           <anchors target='3D View'>


### PR DESCRIPTION
**Problem**:
In Ubuntu 22.04 the buttons of the WorldControl plugin were displayed incorrectly. 

**Solution**:
The problem was caused by the wrong width dimension set in the plugin.

Before:
![Screenshot from 2024-12-05 09-39-18](https://github.com/user-attachments/assets/25a09312-4561-44d9-a5ad-c9712859309e)
Now:
![image](https://github.com/user-attachments/assets/46ebddaf-50e8-4ab0-a046-0325e708754a)
