### PR TITLE
Fix: Imu frame needs to be rotated

### DIFF
--- a/models/gimbal/model.sdf
+++ b/models/gimbal/model.sdf
@@ -202,7 +202,7 @@
       <sensor name="camera_imu" type="imu">
         <always_on>1</always_on>
         <update_rate>250</update_rate>
-        <pose>-0.0412 0 -0.162 0 0 0</pose>
+        <pose>-0.0412 0 -0.162 0 0 3.14</pose>
         <imu>
           <angular_velocity>
             <x>


### PR DESCRIPTION
### Solved Problem
When I tested the gimbal device I notice the angular velocity was moving with wrong angular velocity.

### Test coverage
Tested with QGC

### Context

The original PR with results and description: 
- [x] https://github.com/PX4/PX4-Autopilot/pull/23382
- [x] https://github.com/PX4/PX4-gazebo-models/pull/70

Below is the result of the gimbal in motion and corresponding angular velocities in the gimbal device attitude status.
[07112024pr-gz-gimbal-sim.webm](https://github.com/user-attachments/assets/e1c4269e-4c7b-4020-a22b-27597983ec47)


