### PR TITLE
cameras: fix topic namespaces

### DIFF
--- a/models/OakD-Lite/model.sdf
+++ b/models/OakD-Lite/model.sdf
@@ -4,7 +4,7 @@
     <pose>0 0 0 0 0 0</pose>
     <self_collide>false</self_collide>
     <static>false</static>
-    <link name="OakD-Lite/base_link">
+    <link name="camera_link">
       <inertial>
         <pose>0.00358 -0.03 .014 0 0 0</pose>
         <mass>0.061</mass>

--- a/models/OakD-Lite/model.sdf
+++ b/models/OakD-Lite/model.sdf
@@ -50,7 +50,6 @@
         <always_on>1</always_on>
         <update_rate>30</update_rate>
         <visualize>true</visualize>
-        <topic>camera</topic>
       </sensor>
       <sensor name="StereoOV7251" type="depth_camera">
         <pose>0.01233 -0.03 .01878 0 0 0</pose>

--- a/models/gimbal/model.sdf
+++ b/models/gimbal/model.sdf
@@ -277,7 +277,6 @@
         <always_on>1</always_on>
         <update_rate>30</update_rate>
         <visualize>true</visualize>
-        <topic>camera</topic>
       </sensor>
     </link>
 

--- a/models/mono_cam/model.sdf
+++ b/models/mono_cam/model.sdf
@@ -4,7 +4,7 @@
     <pose>0 0 0 0 0 0</pose>
     <self_collide>false</self_collide>
     <static>false</static>
-    <link name="mono_cam/base_link">
+    <link name="camera_link">
       <inertial>
         <pose>0.03 0.03 0.03 0 0 0</pose>
         <mass>0.050</mass>

--- a/models/mono_cam/model.sdf
+++ b/models/mono_cam/model.sdf
@@ -4,7 +4,7 @@
     <pose>0 0 0 0 0 0</pose>
     <self_collide>false</self_collide>
     <static>false</static>
-    <link name="camera_link">
+    <link name="mono_cam/base_link">
       <inertial>
         <pose>0.03 0.03 0.03 0 0 0</pose>
         <mass>0.050</mass>

--- a/models/mono_cam/model.sdf
+++ b/models/mono_cam/model.sdf
@@ -4,7 +4,7 @@
     <pose>0 0 0 0 0 0</pose>
     <self_collide>false</self_collide>
     <static>false</static>
-    <link name="mono_cam/base_link">
+    <link name="camera_link">
       <inertial>
         <pose>0.03 0.03 0.03 0 0 0</pose>
         <mass>0.050</mass>
@@ -63,7 +63,6 @@
         <always_on>1</always_on>
         <update_rate>30</update_rate>
         <visualize>true</visualize>
-        <topic>camera</topic>
       </sensor>
       <gravity>true</gravity>
       <velocity_decay/>

--- a/models/x500_depth/model.sdf
+++ b/models/x500_depth/model.sdf
@@ -10,7 +10,7 @@
     </include>
     <joint name="CameraJoint" type="fixed">
       <parent>base_link</parent>
-      <child>OakD-Lite/base_link</child>
+      <child>camera_link</child>
       <pose relative_to="base_link">.12 .03 .242 0 0 0</pose>
     </joint>
   </model>

--- a/models/x500_mono_cam/model.sdf
+++ b/models/x500_mono_cam/model.sdf
@@ -10,7 +10,7 @@
     </include>
     <joint name="CameraJoint" type="fixed">
       <parent>base_link</parent>
-      <child>mono_cam/base_link</child>
+      <child>camera_link</child>
       <pose relative_to="base_link">.12 .03 .242 0 0 0</pose>
     </joint>
   </model>

--- a/models/x500_mono_cam/model.sdf
+++ b/models/x500_mono_cam/model.sdf
@@ -10,7 +10,7 @@
     </include>
     <joint name="CameraJoint" type="fixed">
       <parent>base_link</parent>
-      <child>camera_link</child>
+      <child>mono_cam/base_link</child>
       <pose relative_to="base_link">.12 .03 .242 0 0 0</pose>
     </joint>
   </model>

--- a/models/x500_mono_cam_down/model.sdf
+++ b/models/x500_mono_cam_down/model.sdf
@@ -12,7 +12,7 @@
     </include>
     <joint name="CameraJoint" type="fixed">
       <parent>base_link</parent>
-      <child>camera_link</child>
+      <child>mono_cam/base_link</child>
       <pose relative_to="base_link">0 0 0 0 1.5707 0</pose>
     </joint>
   </model>

--- a/models/x500_mono_cam_down/model.sdf
+++ b/models/x500_mono_cam_down/model.sdf
@@ -12,7 +12,7 @@
     </include>
     <joint name="CameraJoint" type="fixed">
       <parent>base_link</parent>
-      <child>mono_cam/base_link</child>
+      <child>camera_link</child>
       <pose relative_to="base_link">0 0 0 0 1.5707 0</pose>
     </joint>
   </model>

--- a/models/x500_mono_cam_down/model.sdf
+++ b/models/x500_mono_cam_down/model.sdf
@@ -5,14 +5,14 @@
     <include merge='true'>
       <uri>x500</uri>
     </include>
-    <include>
+    <include merge='true'>
       <uri>model://mono_cam</uri>
       <pose>0 0 .10 0 1.5707 0</pose>
       <name>mono_cam</name>
     </include>
     <joint name="CameraJoint" type="fixed">
       <parent>base_link</parent>
-      <child>mono_cam::camera_link</child>
+      <child>camera_link</child>
       <pose relative_to="base_link">0 0 0 0 1.5707 0</pose>
     </joint>
   </model>

--- a/models/x500_mono_cam_down/model.sdf
+++ b/models/x500_mono_cam_down/model.sdf
@@ -5,13 +5,14 @@
     <include merge='true'>
       <uri>x500</uri>
     </include>
-    <include merge='true'>
+    <include>
       <uri>model://mono_cam</uri>
       <pose>0 0 .10 0 1.5707 0</pose>
+      <name>mono_cam</name>
     </include>
     <joint name="CameraJoint" type="fixed">
       <parent>base_link</parent>
-      <child>mono_cam/base_link</child>
+      <child>mono_cam::camera_link</child>
       <pose relative_to="base_link">0 0 0 0 1.5707 0</pose>
     </joint>
   </model>


### PR DESCRIPTION
**Problem**
User reported issue in multi-vehicle sim where all camera topics end up with the same name `/camera`

**After this PR**
Topics are namespaced properly
```
/world/default/model/x500_mono_cam_down_1/model/mono_cam/link/camera_link/sensor/imager/camera_info
/world/default/model/x500_mono_cam_down_1/model/mono_cam/link/camera_link/sensor/imager/image
/world/default/model/x500_mono_cam_down_2/model/mono_cam/link/camera_link/sensor/imager/camera_info
/world/default/model/x500_mono_cam_down_2/model/mono_cam/link/camera_link/sensor/imager/image

```