### PR TITLE
Fix IMU + baro noise model

### DIFF
--- a/models/x500_base/model.sdf
+++ b/models/x500_base/model.sdf
@@ -219,10 +219,11 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
+          <!-- Noise modeled after BMP390 -->
           <pressure>
             <noise type="gaussian">
               <mean>0</mean>
-              <stddev>0.01</stddev>
+              <stddev>3</stddev>
             </noise>
           </pressure>
         </air_pressure>

--- a/models/x500_base/model.sdf
+++ b/models/x500_base/model.sdf
@@ -232,54 +232,47 @@
         <update_rate>250</update_rate>
         <imu>
           <angular_velocity>
+            <!-- Noise modeled after IIM42653 -->
+            <!-- 0.05 deg/s converted to rad/s -->
             <x>
               <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.00018665</stddev>
-                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+                <mean>0.0</mean>
+                <stddev>0.0008726646</stddev>
               </noise>
             </x>
             <y>
               <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.00018665</stddev>
-                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+                <mean>0.0</mean>
+                <stddev>0.0008726646</stddev>
               </noise>
             </y>
             <z>
               <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.00018665</stddev>
-                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+                <mean>0.0</mean>
+                <stddev>0.0008726646</stddev>
               </noise>
             </z>
           </angular_velocity>
           <linear_acceleration>
+            <!-- Noise modeled after IIM42653 -->
+            <!-- X & Y axis: 0.65 mg-rms converted to m/ss -->
             <x>
               <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.00186</stddev>
-                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+                <mean>0.0</mean>
+                <stddev>0.00637</stddev>
               </noise>
             </x>
             <y>
               <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.00186</stddev>
-                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+                <mean>0.0</mean>
+                <stddev>0.00637</stddev>
               </noise>
             </y>
+            <!-- Z axis: 0.70 mg-rms converted to m/ss-->
             <z>
               <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.00186</stddev>
-                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+                <mean>0.0</mean>
+                <stddev>0.00686</stddev>
               </noise>
             </z>
           </linear_acceleration>


### PR DESCRIPTION
The IMU noise model is not representative of real world sensors and the random walk causes altitude estimation instability. In practice an IMU will tend to have little to no random walk. 

**Before**
![Screenshot from 2025-02-25 17-39-57](https://github.com/user-attachments/assets/033588ca-682d-464b-9d36-762bbf3e877d)

**After**
![Screenshot from 2025-02-25 17-40-09](https://github.com/user-attachments/assets/2de394e0-fa4e-4548-9fdd-eeeac4fc3fb4)
