### PR TITLE
plugins: remove plugins from worlds, use server config file

### DIFF
--- a/sdf_parsing/check_sdf.cc
+++ b/sdf_parsing/check_sdf.cc
@@ -27,7 +27,7 @@ int main(int argc, const char* argv[])
   if (!rootElement->HasElement("model"))
   {
     std::cerr << sdfPath << " is not a model SDF file!" << std::endl;
-    return -3;
+    return 0;
   }
   const sdf::ElementPtr modelElement = rootElement->GetElement("model");
   const std::string modelName = modelElement->Get<std::string>("name");

--- a/worlds/aruco.sdf
+++ b/worlds/aruco.sdf
@@ -6,17 +6,6 @@
       <real_time_factor>1.0</real_time_factor>
       <real_time_update_rate>250</real_time_update_rate>
     </physics>
-    <plugin name="gz::sim::systems::Physics" filename="gz-sim-physics-system"/>
-    <plugin name="gz::sim::systems::UserCommands" filename="gz-sim-user-commands-system"/>
-    <plugin name="gz::sim::systems::SceneBroadcaster" filename="gz-sim-scene-broadcaster-system"/>
-    <plugin name="gz::sim::systems::Contact" filename="gz-sim-contact-system"/>
-    <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system"/>
-    <plugin name="gz::sim::systems::AirPressure" filename="gz-sim-air-pressure-system"/>
-    <plugin name="gz::sim::systems::ApplyLinkWrench" filename="gz-sim-apply-link-wrench-system"/>
-    <plugin name="gz::sim::systems::NavSat" filename="gz-sim-navsat-system"/>
-    <plugin name="gz::sim::systems::Sensors" filename="gz-sim-sensors-system">
-      <render_engine>ogre2</render_engine>
-    </plugin>
     <gui fullscreen="false">
       <!-- 3D scene -->
       <plugin filename="MinimalScene" name="3D View">

--- a/worlds/baylands.sdf
+++ b/worlds/baylands.sdf
@@ -5,17 +5,6 @@
       <real_time_factor>1.0</real_time_factor>
       <real_time_update_rate>250</real_time_update_rate>
     </physics>
-    <plugin name='gz::sim::systems::Physics' filename='gz-sim-physics-system'/>
-    <plugin name='gz::sim::systems::UserCommands' filename='gz-sim-user-commands-system'/>
-    <plugin name='gz::sim::systems::SceneBroadcaster' filename='gz-sim-scene-broadcaster-system'/>
-    <plugin name='gz::sim::systems::Contact' filename='gz-sim-contact-system'/>
-    <plugin name='gz::sim::systems::Imu' filename='gz-sim-imu-system'/>
-    <plugin name='gz::sim::systems::AirPressure' filename='gz-sim-air-pressure-system'/>
-    <plugin name='gz::sim::systems::ApplyLinkWrench' filename='gz-sim-apply-link-wrench-system'/>
-    <plugin name='gz::sim::systems::NavSat' filename='gz-sim-navsat-system'/>
-    <plugin name='gz::sim::systems::Sensors' filename='gz-sim-sensors-system'>
-      <render_engine>ogre2</render_engine>
-    </plugin>
     <gui fullscreen='false'>
 
       <!-- 3D scene -->

--- a/worlds/default.sdf
+++ b/worlds/default.sdf
@@ -6,18 +6,6 @@
       <real_time_factor>1.0</real_time_factor>
       <real_time_update_rate>250</real_time_update_rate>
     </physics>
-    <plugin name="gz::sim::systems::Physics" filename="gz-sim-physics-system"/>
-    <plugin name="gz::sim::systems::UserCommands" filename="gz-sim-user-commands-system"/>
-    <plugin name="gz::sim::systems::SceneBroadcaster" filename="gz-sim-scene-broadcaster-system"/>
-    <plugin name="gz::sim::systems::Contact" filename="gz-sim-contact-system"/>
-    <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system"/>
-    <plugin name="gz::sim::systems::AirPressure" filename="gz-sim-air-pressure-system"/>
-    <plugin name="gz::sim::systems::AirSpeed" filename="gz-sim-air-speed-system"/>
-    <plugin name="gz::sim::systems::ApplyLinkWrench" filename="gz-sim-apply-link-wrench-system"/>
-    <plugin name="gz::sim::systems::NavSat" filename="gz-sim-navsat-system"/>
-    <plugin name="gz::sim::systems::Sensors" filename="gz-sim-sensors-system">
-      <render_engine>ogre2</render_engine>
-    </plugin>
     <gui fullscreen="false">
       <!-- 3D scene -->
       <plugin filename="MinimalScene" name="3D View">

--- a/worlds/default.sdf
+++ b/worlds/default.sdf
@@ -174,7 +174,7 @@
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>100 100</size>
+              <size>500 500</size>
             </plane>
           </geometry>
           <material>

--- a/worlds/forest.sdf
+++ b/worlds/forest.sdf
@@ -6,21 +6,6 @@
       <real_time_factor>1.0</real_time_factor>
       <real_time_update_rate>250</real_time_update_rate>
     </physics>
-    <plugin name="gz::sim::systems::Physics" filename="gz-sim-physics-system"/>
-    <plugin name="gz::sim::systems::UserCommands" filename="gz-sim-user-commands-system"/>
-    <plugin name="gz::sim::systems::SceneBroadcaster" filename="gz-sim-scene-broadcaster-system"/>
-    <plugin name="gz::sim::systems::Contact" filename="gz-sim-contact-system"/>
-    <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system"/>
-    <plugin name="gz::sim::systems::AirPressure" filename="gz-sim-air-pressure-system"/>
-    <plugin name="gz::sim::systems::AirSpeed" filename="gz-sim-air-speed-system"/>
-    <plugin name="gz::sim::systems::ApplyLinkWrench" filename="gz-sim-apply-link-wrench-system"/>
-    <plugin name="gz::sim::systems::NavSat" filename="gz-sim-navsat-system"/>
-    <plugin name="gz::sim::systems::Sensors" filename="gz-sim-sensors-system">
-      <render_engine>ogre2</render_engine>
-    </plugin>
-    <!-- PX4 custom plugins -->
-    <plugin name="custom::OpticalFlowSystem" filename="libOpticalFlowSystem.so" />
-
     <gui fullscreen="false">
       <!-- 3D scene -->
       <plugin filename="MinimalScene" name="3D View">

--- a/worlds/frictionless.sdf
+++ b/worlds/frictionless.sdf
@@ -27,17 +27,6 @@
       <real_time_update_rate>250</real_time_update_rate>
       <magnetic_field>6.0e-6 2.3e-5 -4.2e-5</magnetic_field>
     </physics>
-    <plugin name="gz::sim::systems::Physics" filename="gz-sim-physics-system"/>
-    <plugin name="gz::sim::systems::UserCommands" filename="gz-sim-user-commands-system"/>
-    <plugin name="gz::sim::systems::SceneBroadcaster" filename="gz-sim-scene-broadcaster-system"/>
-    <plugin name="gz::sim::systems::Contact" filename="gz-sim-contact-system"/>
-    <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system"/>
-    <plugin name="gz::sim::systems::AirPressure" filename="gz-sim-air-pressure-system"/>
-    <plugin name="gz::sim::systems::ApplyLinkWrench" filename="gz-sim-apply-link-wrench-system"/>
-    <plugin name="gz::sim::systems::NavSat" filename="gz-sim-navsat-system"/>
-    <plugin name="gz::sim::systems::Sensors" filename="gz-sim-sensors-system">
-      <render_engine>ogre2</render_engine>
-    </plugin>
     <gui fullscreen="false">
       <!-- 3D scene -->
       <plugin filename="MinimalScene" name="3D View">

--- a/worlds/lawn.sdf
+++ b/worlds/lawn.sdf
@@ -6,17 +6,6 @@
       <real_time_factor>1.0</real_time_factor>
       <real_time_update_rate>250</real_time_update_rate>
     </physics>
-    <plugin name="gz::sim::systems::Physics" filename="gz-sim-physics-system"/>
-    <plugin name="gz::sim::systems::UserCommands" filename="gz-sim-user-commands-system"/>
-    <plugin name="gz::sim::systems::SceneBroadcaster" filename="gz-sim-scene-broadcaster-system"/>
-    <plugin name="gz::sim::systems::Contact" filename="gz-sim-contact-system"/>
-    <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system"/>
-    <plugin name="gz::sim::systems::AirPressure" filename="gz-sim-air-pressure-system"/>
-    <plugin name="gz::sim::systems::ApplyLinkWrench" filename="gz-sim-apply-link-wrench-system"/>
-    <plugin name="gz::sim::systems::NavSat" filename="gz-sim-navsat-system"/>
-    <plugin name="gz::sim::systems::Sensors" filename="gz-sim-sensors-system">
-      <render_engine>ogre2</render_engine>
-    </plugin>
     <gui fullscreen="false">
       <!-- 3D scene -->
       <plugin filename="MinimalScene" name="3D View">

--- a/worlds/rover.sdf
+++ b/worlds/rover.sdf
@@ -6,17 +6,6 @@
       <real_time_factor>1.0</real_time_factor>
       <real_time_update_rate>500</real_time_update_rate>
     </physics>
-    <plugin name="gz::sim::systems::Physics" filename="gz-sim-physics-system"/>
-    <plugin name="gz::sim::systems::UserCommands" filename="gz-sim-user-commands-system"/>
-    <plugin name="gz::sim::systems::SceneBroadcaster" filename="gz-sim-scene-broadcaster-system"/>
-    <plugin name="gz::sim::systems::Contact" filename="gz-sim-contact-system"/>
-    <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system"/>
-    <plugin name="gz::sim::systems::AirPressure" filename="gz-sim-air-pressure-system"/>
-    <plugin name="gz::sim::systems::ApplyLinkWrench" filename="gz-sim-apply-link-wrench-system"/>
-    <plugin name="gz::sim::systems::NavSat" filename="gz-sim-navsat-system"/>
-    <plugin name="gz::sim::systems::Sensors" filename="gz-sim-sensors-system">
-      <render_engine>ogre2</render_engine>
-    </plugin>
     <gui fullscreen="false">
       <!-- 3D scene -->
       <plugin filename="MinimalScene" name="3D View">

--- a/worlds/walls.sdf
+++ b/worlds/walls.sdf
@@ -6,17 +6,6 @@
       <real_time_factor>1.0</real_time_factor>
       <real_time_update_rate>250</real_time_update_rate>
     </physics>
-    <plugin name="gz::sim::systems::Physics" filename="gz-sim-physics-system"/>
-    <plugin name="gz::sim::systems::UserCommands" filename="gz-sim-user-commands-system"/>
-    <plugin name="gz::sim::systems::SceneBroadcaster" filename="gz-sim-scene-broadcaster-system"/>
-    <plugin name="gz::sim::systems::Contact" filename="gz-sim-contact-system"/>
-    <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system"/>
-    <plugin name="gz::sim::systems::AirPressure" filename="gz-sim-air-pressure-system"/>
-    <plugin name="gz::sim::systems::ApplyLinkWrench" filename="gz-sim-apply-link-wrench-system"/>
-    <plugin name="gz::sim::systems::NavSat" filename="gz-sim-navsat-system"/>
-    <plugin name="gz::sim::systems::Sensors" filename="gz-sim-sensors-system">
-      <render_engine>ogre2</render_engine>
-    </plugin>
     <gui fullscreen="false">
       <!-- 3D scene -->
       <plugin filename="MinimalScene" name="3D View">

--- a/worlds/windy.sdf
+++ b/worlds/windy.sdf
@@ -5,17 +5,6 @@
       <real_time_factor>1.0</real_time_factor>
       <real_time_update_rate>250</real_time_update_rate>
     </physics>
-    <plugin name='gz::sim::systems::Physics' filename='gz-sim-physics-system'/>
-    <plugin name='gz::sim::systems::UserCommands' filename='gz-sim-user-commands-system'/>
-    <plugin name='gz::sim::systems::SceneBroadcaster' filename='gz-sim-scene-broadcaster-system'/>
-    <plugin name='gz::sim::systems::Contact' filename='gz-sim-contact-system'/>
-    <plugin name='gz::sim::systems::Imu' filename='gz-sim-imu-system'/>
-    <plugin name='gz::sim::systems::AirPressure' filename='gz-sim-air-pressure-system'/>
-    <plugin name='gz::sim::systems::ApplyLinkWrench' filename='gz-sim-apply-link-wrench-system'/>
-    <plugin name='gz::sim::systems::NavSat' filename='gz-sim-navsat-system'/>
-    <plugin name='gz::sim::systems::Sensors' filename='gz-sim-sensors-system'>
-      <render_engine>ogre2</render_engine>
-    </plugin>
     <gui fullscreen='false'>
       
       <!-- 3D scene -->


### PR DESCRIPTION
See gazebo docs
https://gazebosim.org/api/sim/8/server_config.html

TLDR; the plugins can be loaded via a config file. This ensures we have all the plugins needed for PX4 without hardcoding them into the world files.

Depends on https://github.com/PX4/PX4-Autopilot/pull/24441