### PR TITLE
moving platform: add IMU sensor

### DIFF
--- a/models/moving_platform/model.sdf
+++ b/models/moving_platform/model.sdf
@@ -34,12 +34,17 @@
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>
+      <sensor name="imu_sensor" type="imu">
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+      </sensor>
     </link>
     <!-- plugin for sending direct velocity commands -->
     <plugin
       filename="gz-sim-velocity-control-system"
       name="gz::sim::systems::VelocityControl">
     </plugin>
+    <!-- plugin for controlling platform movement -->
     <plugin
       filename="libMovingPlatformController.so"
       name="custom::MovingPlatformController">


### PR DESCRIPTION
As discussed in https://github.com/PX4/PX4-Autopilot/pull/24471 we will keep the platform simple and refrain from interfacing with PX4 for now. Instead we add this IMU sensor as a very simple way to get the pose info from the simulation. 