### PR TITLE
r1_rover: fix error when starting simulation

### DIFF
--- a/models/r1_rover/model.config
+++ b/models/r1_rover/model.config
@@ -2,7 +2,7 @@
 <model>
   <name>r1_rover</name>
   <version>1.0</version>
-  <sdf version='1.5'>r1_rover.sdf</sdf>
+  <sdf version='1.5'>model.sdf</sdf>
   <license>https://github.com/aionrobotics/aion_io/blob/master/LICENSE.txt</license>
 
   <author>


### PR DESCRIPTION
Fixes the following error when starting the r1_rover simulation introduced by https://github.com/PX4/PX4-Autopilot/pull/24421

>[Err] [UserCommands.cc:1152] Error Code 1: Msg: File [/home/christian/Workspaces/PX4-Autopilot/Tools/simulation/gz/models/r1_rover/r1_rover.sdf] doesn't exist.
[Err] [UserCommands.cc:1152] Error Code 1: Msg: Unable to read file: [/home/christian/Workspaces/PX4-Autopilot/Tools/simulation/gz/models/r1_rover]
