### PR TITLE
moving platform: remove velocity plugin, add link name

### DIFF
--- a/models/moving_platform/model.sdf
+++ b/models/moving_platform/model.sdf
@@ -35,14 +35,10 @@
         <update_rate>30</update_rate>
       </sensor>
     </link>
-    <!-- plugin for sending direct velocity commands -->
-    <plugin
-      filename="gz-sim-velocity-control-system"
-      name="gz::sim::systems::VelocityControl">
-    </plugin>
     <plugin
       filename="libMovingPlatformController.so"
       name="custom::MovingPlatformController">
+      <link_name>platform_link</link_name>
     </plugin>
   </model>
 </sdf>


### PR DESCRIPTION
I'm changing the plugin from velocity control to force control to keep it physically realistic, as [discussed here](https://github.com/PX4/PX4-Autopilot/pull/24471).

For good force control, we need velocity feedback, and it turns out the velocity plugin makes gazebo report 0 velocity. So we need to remove it completely rather than just stop using it. 

I'm adding the link name here so we can refer to the link directly without hardcoding it in the plugin. 