### PR TITLE
feat: Add KTH Space Robotics Lab simulation world

### DIFF
--- a/worlds/kthspacelab.sdf
+++ b/worlds/kthspacelab.sdf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <sdf version="1.9">
-  <world name="kth_space_lab">
+  <world name="kthspacelab">
     <physics type="ode">
       <max_step_size>0.006</max_step_size>
       <real_time_factor>1.0</real_time_factor>


### PR DESCRIPTION
This PR adds a new Gazebo simulation world that mimics the *Space Robotics Lab* at KTH Royal Institute of Technology, where we conduct planar (2D) spacecraft experiments using frictionless free-flyer robots.

### About the World
- Provided as a standalone file `kth_space_lab_world.df`.
- The layout matches the physical setup of the lab, including its non-rectangular boundaries.
- It uses the same coordinate frame as the motion capture system in the real lab.
- Designed for use with the existing `spacecraft_2d` model in this repository, which simulates frictionless 2D motion using spacecraft thrusters.

![kth_space_lab_world](https://github.com/user-attachments/assets/79456fda-2862-4083-a756-dd4612abb468)

---

Let me know if any additional documentation or context is needed.