### PR TITLE
ADD: airspeed sensor to each fw model

### DIFF
--- a/models/advanced_plane/model.sdf
+++ b/models/advanced_plane/model.sdf
@@ -151,6 +151,17 @@
         <update_rate>30</update_rate>
       </sensor>
     </link>
+    
+    <include merge="true">
+      <uri>model://airspeed</uri>
+      <pose>0.16 0 -0.05 0 0 0</pose>
+    </include>
+    <joint name='airspeed_joint' type='fixed'>
+      <parent>base_link</parent>
+      <child>airspeed_link</child>
+      <pose relative_to="base_link">-0 0 0 0 0 0</pose>
+    </joint>
+    
     <link name='rotor_puller'>
       <pose>0.3 0 0.0 0 1.57 0</pose>
       <inertial>

--- a/models/rc_cessna/model.sdf
+++ b/models/rc_cessna/model.sdf
@@ -180,7 +180,8 @@
         </magnetometer>
       </sensor>
     </link>
-    <link name="airspeed">
+    
+    <!-- <link name="airspeed">
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
@@ -206,7 +207,7 @@
           <diffuse>0 0 0 1.0</diffuse>
         </material>
       </visual>
-      <!-- <sensor name="air_speed" type="air_speed">
+      <sensor name="air_speed" type="air_speed">
         <always_on>1</always_on>
         <update_rate>5.0</update_rate>
         <enable_metrics>false</enable_metrics>
@@ -218,12 +219,23 @@
             </noise>
           </airspeed>
         </air_speed>
-      </sensor> -->
+      </sensor>
     </link>
     <joint name='airspeed_joint' type='fixed'>
       <child>airspeed</child>
       <parent>base_link</parent>
+    </joint>-->
+    
+    <include merge="true">
+      <uri>model://airspeed</uri>
+      <pose>0.16 0 -0.05 0 0 0</pose>
+    </include>
+    <joint name='airspeed_joint' type='fixed'>
+      <parent>base_link</parent>
+      <child>airspeed_link</child>
+      <pose relative_to="base_link">-0 0 0 0 0 0</pose>
     </joint>
+    
     <link name='rotor_puller'>
       <pose>0.22 0 0.0 0 1.57079632679 0</pose>
       <inertial>

--- a/models/standard_vtol/model.sdf
+++ b/models/standard_vtol/model.sdf
@@ -230,6 +230,17 @@
         <update_rate>30</update_rate>
       </sensor>
     </link>
+    
+    <include merge="true">
+      <uri>model://airspeed</uri>
+      <pose >0.49 0 -0.05 0 0 0</pose>
+    </include>
+    <joint name='airspeed_joint' type='fixed'>
+      <parent>base_link</parent>
+      <child>airspeed_link</child>
+      <pose relative_to="base_link">-0 0 0 0 0 0</pose>
+    </joint>
+
     <link name='rotor_0'>
       <pose>0.35 -0.35 0.07 0 0 0</pose>
       <inertial>


### PR DESCRIPTION
According to the discussion in https://github.com/PX4/PX4-Autopilot/pull/24452

It is better to add airspeed sensors to every fixed-wing model, including:
1. standard_vtol
2. rc_cessna
3. advanced_plane