### PR TITLE
feat: add real wind effect on multicopter-like models with WindEffects gz plugin

### DIFF
--- a/models/advanced_plane/model.sdf
+++ b/models/advanced_plane/model.sdf
@@ -3,6 +3,7 @@
   <model name='advanced_plane'>
     <pose>0 0 0.246 0 0 0</pose>
     <link name='base_link'>
+      <enable_wind>false</enable_wind>
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>

--- a/models/omnicopter/model.sdf
+++ b/models/omnicopter/model.sdf
@@ -4,6 +4,7 @@
     <self_collide>false</self_collide>
     <static>false</static>
     <link name='base_link'>
+      <enable_wind>true</enable_wind>
       <pose>0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0 0 -0 0</pose>

--- a/models/px4vision/model.sdf
+++ b/models/px4vision/model.sdf
@@ -5,6 +5,7 @@
     <self_collide>false</self_collide>
     <static>false</static>
     <link name='base_link'>
+      <enable_wind>true</enable_wind>
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>

--- a/models/quadtailsitter/model.sdf
+++ b/models/quadtailsitter/model.sdf
@@ -2,6 +2,7 @@
 <sdf version='1.10'>
   <model name='quadtailsitter'>
     <link name='base_link'>
+      <enable_wind>false</enable_wind>
       <pose>0 0 0.4 0 0 0</pose>
       <inertial>
         <pose>0 0 0.05 0 0 0</pose>

--- a/models/rc_cessna/model.sdf
+++ b/models/rc_cessna/model.sdf
@@ -3,6 +3,7 @@
   <model name='rc_cessna'>
     <pose>0 0 0.246 0 0 0</pose>
     <link name='base_link'>
+      <enable_wind>false</enable_wind>
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>

--- a/models/standard_vtol/model.sdf
+++ b/models/standard_vtol/model.sdf
@@ -4,6 +4,7 @@
   <model name='standard_vtol'>
     <pose>0 0 0.246 0 0 0</pose>
     <link name='base_link'>
+      <enable_wind>false</enable_wind>
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>

--- a/models/tiltrotor/model.sdf
+++ b/models/tiltrotor/model.sdf
@@ -4,6 +4,7 @@
   <model name='tiltrotor'>
     <pose>0 0 0.246 0 0 0</pose>
     <link name='base_link'>
+      <enable_wind>true</enable_wind>
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>

--- a/models/x500_base/model.sdf
+++ b/models/x500_base/model.sdf
@@ -5,6 +5,7 @@
     <self_collide>false</self_collide>
     <static>false</static>
     <link name="base_link">
+      <enable_wind>true</enable_wind>
       <inertial>
         <mass>2.0</mass>
         <inertia>

--- a/worlds/windy.sdf
+++ b/worlds/windy.sdf
@@ -82,7 +82,7 @@
       </spot>
     </light>
     <wind>
-      <linear_velocity>5 2 0</linear_velocity>
+      <linear_velocity>0 0 0</linear_velocity>
     </wind>
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>

--- a/worlds/windy.sdf
+++ b/worlds/windy.sdf
@@ -58,7 +58,6 @@
             <izz>1</izz>
           </inertia>
         </inertial>
-        <enable_wind>true</enable_wind>
       </link>
       <pose>0 0 0 0 -0 0</pose>
       <self_collide>false</self_collide>
@@ -92,5 +91,41 @@
       <longitude_deg> 8.546163739800146</longitude_deg>
       <elevation>0</elevation>
     </spherical_coordinates>
+    <!-- Load the plugin for the wind -->
+    <plugin
+      filename="gz-sim-wind-effects-system"
+      name="gz::sim::systems::WindEffects">
+      <force_approximation_scaling_factor>1</force_approximation_scaling_factor>
+      <horizontal>
+        <magnitude>
+          <time_for_rise>10</time_for_rise>
+          <sin>
+            <amplitude_percent>0.05</amplitude_percent>
+            <period>60</period>
+          </sin>
+          <noise type="gaussian">
+           <mean>0</mean>
+           <stddev>0.0002</stddev>
+          </noise>
+        </magnitude>
+        <direction>
+          <time_for_rise>30</time_for_rise>
+          <sin>
+            <amplitude>5</amplitude>
+            <period>20</period>
+          </sin>
+          <noise type="gaussian">
+           <mean>0</mean>
+           <stddev>0.03</stddev>
+          </noise>
+        </direction>
+      </horizontal>
+      <vertical>
+        <noise type="gaussian">
+         <mean>0</mean>
+         <stddev>0.03</stddev>
+        </noise>
+      </vertical>
+    </plugin>
   </world>
 </sdf>


### PR DESCRIPTION
This PR adds the `gz::sim::systems::WindEffects` plugin to the `windy.sdf` world which properly simulates wind effects on links having `<enable_wind>true</enable_wind>`.

Gazebo [wind.sdf](https://github.com/gazebosim/gz-sim/blob/gz-sim10/examples/worlds/wind.sdf) example world has been used as template for setting the parameters for the plugin.

Initial wind speed is set to zero but it can be changed by publishing on the `/world/windy/wind/` gz topic like this:

```sh
gz topic -t "/world/windy/wind/" -m gz.msgs.Wind  -p "linear_velocity: {x:10, y:0, z:0}, enable_wind: true"
```

which will apply `10m/s` wind speed in gz x direction (PX4 EAST direction as gz uses ENU and PX4 uses NED).

The changes has been tested in on the x500 model using **Gazebo Jetty**:

https://github.com/user-attachments/assets/61be5916-f3e1-4a4f-a53b-36903cbbac9f

**On Gazebo Harmonic the world did not load correctly** even if the gazebo [wind.sdf](https://github.com/gazebosim/gz-sim/blob/gz-sim8/examples/worlds/wind.sdf) example world for gazebo harmonic works just fine.

However, I don't see this as a blocking issue as currently the windy world has no effect and it is practically equivalent to the default world. Therefore no existing logic is broken with this PR. Users using windy world on GZ Harmonic can simply switch to the default one.

---

No FW model (rc_cessna, advanced_plane) has wind enabled in this PR: if enabled the plane does not manage to takeoff, further investigation is required for them.
