### PR TITLE
fix: remove gz_frame_id elements causing SDF schema warnings

### DIFF
--- a/models/OakD-Lite/model.sdf
+++ b/models/OakD-Lite/model.sdf
@@ -35,7 +35,6 @@
         </geometry>
       </collision>
       <sensor name="IMX214" type="camera">
-        <gz_frame_id>camera_link</gz_frame_id>
         <pose>0.01233 -0.03 .01878 0 0 0</pose>
         <camera>
           <horizontal_fov>1.204</horizontal_fov>
@@ -53,7 +52,6 @@
         <visualize>true</visualize>
       </sensor>
       <sensor name="StereoOV7251" type="depth_camera">
-        <gz_frame_id>camera_link</gz_frame_id>
         <pose>0.01233 -0.03 .01878 0 0 0</pose>
         <camera>
           <horizontal_fov>1.274</horizontal_fov>

--- a/models/advanced_plane/model.sdf
+++ b/models/advanced_plane/model.sdf
@@ -52,7 +52,6 @@
       <velocity_decay />
       <self_collide>0</self_collide>
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
@@ -111,7 +110,6 @@
         </imu>
       </sensor>
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -124,7 +122,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -150,7 +147,6 @@
         </magnetometer>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>
@@ -432,7 +428,6 @@
         </inertia>
       </inertial>
       <sensor name='lidar' type='gpu_lidar'>
-        <gz_frame_id>lidar_sensor_link</gz_frame_id>
         <pose>0 0 0 3.14 0 0</pose>
         <update_rate>50</update_rate>
         <ray>

--- a/models/airspeed/model.sdf
+++ b/models/airspeed/model.sdf
@@ -29,7 +29,6 @@
         </material>
       </visual>
       <sensor name="air_speed" type="air_speed">
-        <gz_frame_id>airspeed_link</gz_frame_id>
         <pose>0 0 0 0 0 0</pose>
         <update_rate>5.0</update_rate>
         <always_on>1</always_on>

--- a/models/gimbal/model.sdf
+++ b/models/gimbal/model.sdf
@@ -200,7 +200,6 @@
       </visual>
 
       <sensor name="camera_imu" type="imu">
-        <gz_frame_id>camera_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <pose>-0.0412 0 -0.162 0 0 3.14</pose>
@@ -261,7 +260,6 @@
       </sensor>
 
       <sensor name="camera" type="camera">
-        <gz_frame_id>camera_link</gz_frame_id>
         <pose>-0.0412 0 -0.162 0 0 3.14</pose>
         <camera>
           <horizontal_fov>2.0</horizontal_fov>

--- a/models/lawnmower/model.sdf
+++ b/models/lawnmower/model.sdf
@@ -203,7 +203,6 @@
         </material>
       </visual>
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -216,7 +215,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -242,12 +240,10 @@
         </magnetometer>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>

--- a/models/lidar_2d_v2/model.sdf
+++ b/models/lidar_2d_v2/model.sdf
@@ -48,7 +48,6 @@
         </geometry>
       </visual>
       <sensor name="lidar_2d_v2" type="gpu_lidar">
-        <gz_frame_id>link</gz_frame_id>
         <pose>0 0 0.055 0 0 0</pose>
         <ray>
           <scan>

--- a/models/mono_cam/model.sdf
+++ b/models/mono_cam/model.sdf
@@ -48,7 +48,6 @@
         </material>
       </visual>
       <sensor name="camera" type="camera">
-        <gz_frame_id>camera_link</gz_frame_id>
         <pose>0 0 0 0 0 0</pose>
         <camera>
           <horizontal_fov>1.74</horizontal_fov>

--- a/models/moving_platform/model.sdf
+++ b/models/moving_platform/model.sdf
@@ -31,7 +31,6 @@
         </inertia>
       </inertial>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>platform_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>

--- a/models/omnicopter/model.sdf
+++ b/models/omnicopter/model.sdf
@@ -54,7 +54,6 @@
       <gravity>true</gravity>
       <velocity_decay />
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -67,7 +66,6 @@
         </air_pressure>
       </sensor>
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
@@ -126,7 +124,6 @@
         </imu>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -152,7 +149,6 @@
         </magnetometer>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>

--- a/models/optical_flow/model.sdf
+++ b/models/optical_flow/model.sdf
@@ -53,7 +53,6 @@
         </material>
       </visual>
       <sensor name="flow_camera" type="camera">
-        <gz_frame_id>flow_link</gz_frame_id>
         <pose>0 0 0 0 1.5707 0</pose>
         <camera>
           <horizontal_fov>0.733038</horizontal_fov>
@@ -71,7 +70,6 @@
         <visualize>true</visualize>
       </sensor>
       <sensor name="optical_flow" type="custom" gz:type="optical_flow">
-        <gz_frame_id>flow_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <visualize>true</visualize>

--- a/models/px4vision/model.sdf
+++ b/models/px4vision/model.sdf
@@ -54,7 +54,6 @@
         </material>
       </visual>
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -67,7 +66,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -93,12 +91,10 @@
         </magnetometer>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>

--- a/models/quadtailsitter/model.sdf
+++ b/models/quadtailsitter/model.sdf
@@ -57,7 +57,6 @@
       <self_collide>0</self_collide>
 
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
@@ -116,7 +115,6 @@
         </imu>
       </sensor>
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -129,7 +127,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -155,7 +152,6 @@
         </magnetometer>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>

--- a/models/r1_rover/model.sdf
+++ b/models/r1_rover/model.sdf
@@ -116,7 +116,6 @@
       <gravity>1</gravity>
       <velocity_decay />
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
@@ -175,7 +174,6 @@
         </imu>
       </sensor>
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -188,7 +186,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -214,7 +211,6 @@
         </magnetometer>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>

--- a/models/rc_cessna/model.sdf
+++ b/models/rc_cessna/model.sdf
@@ -81,7 +81,6 @@
       <velocity_decay />
       <self_collide>0</self_collide>
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
@@ -140,12 +139,10 @@
         </imu>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -158,7 +155,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -211,7 +207,6 @@
         </material>
       </visual>
       <!-- <sensor name="air_speed" type="air_speed">
-        <gz_frame_id>airspeed</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>5.0</update_rate>
         <enable_metrics>false</enable_metrics>

--- a/models/rover_differential/model.sdf
+++ b/models/rover_differential/model.sdf
@@ -34,7 +34,6 @@
 
       <!--Sensors-->
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -48,7 +47,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -74,7 +72,6 @@
         </magnetometer>
       </sensor>
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
@@ -126,7 +123,6 @@
         </imu>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>

--- a/models/standard_vtol/model.sdf
+++ b/models/standard_vtol/model.sdf
@@ -131,7 +131,6 @@
       <velocity_decay />
       <self_collide>0</self_collide>
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
@@ -190,7 +189,6 @@
         </imu>
       </sensor>
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -203,7 +201,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -229,7 +226,6 @@
         </magnetometer>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>

--- a/models/tiltrotor/model.sdf
+++ b/models/tiltrotor/model.sdf
@@ -106,7 +106,6 @@
       <self_collide>0</self_collide>
 
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
@@ -165,7 +164,6 @@
         </imu>
       </sensor>
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -178,7 +176,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -204,7 +201,6 @@
         </magnetometer>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>

--- a/models/x500_base/model.sdf
+++ b/models/x500_base/model.sdf
@@ -216,7 +216,6 @@
         </surface>
       </collision>
       <sensor name="air_pressure_sensor" type="air_pressure">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <air_pressure>
@@ -230,7 +229,6 @@
         </air_pressure>
       </sensor>
       <sensor name="magnetometer_sensor" type="magnetometer">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <magnetometer>
@@ -256,7 +254,6 @@
         </magnetometer>
       </sensor>
       <sensor name="imu_sensor" type="imu">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
@@ -308,7 +305,6 @@
         </imu>
       </sensor>
       <sensor name="navsat_sensor" type="navsat">
-        <gz_frame_id>base_link</gz_frame_id>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
       </sensor>

--- a/models/x500_flow/model.sdf
+++ b/models/x500_flow/model.sdf
@@ -41,7 +41,6 @@
         </inertia>
       </inertial>
       <sensor name='lidar' type='gpu_lidar'>
-        <gz_frame_id>lidar_sensor_link</gz_frame_id>
         <pose>0 0 0 3.14 0 0</pose>
         <update_rate>50</update_rate>
         <ray>

--- a/models/x500_lidar_down/model.sdf
+++ b/models/x500_lidar_down/model.sdf
@@ -32,7 +32,6 @@
         </inertia>
       </inertial>
       <sensor name='lidar' type='gpu_lidar'>
-        <gz_frame_id>lidar_sensor_link</gz_frame_id>
         <pose>0 0 0 3.14 0 0</pose>
         <update_rate>50</update_rate>
         <ray>

--- a/models/x500_lidar_front/model.sdf
+++ b/models/x500_lidar_front/model.sdf
@@ -27,7 +27,6 @@
         </inertia>
       </inertial>
       <sensor name='lidar' type='gpu_lidar'>
-        <gz_frame_id>lidar_sensor_link</gz_frame_id>
         <pose relative_to="base_link">.15 0 .01 1.57 0 0</pose>
         <update_rate>50</update_rate>
         <ray>


### PR DESCRIPTION
gz_frame_id is not a recognized SDF 1.9 element at the sensor level. Gazebo Harmonic (gz-sim 8.x) warns on every sensor that uses it:
  'XML Element[gz_frame_id]...not defined in SDF. Copying as children'

Sensors attached to a link naturally report in that link's frame without requiring the gz_frame_id hint. Removing these elements eliminates 59 warnings across 21 model files with no functional impact.

Affects: x500_base, x500_flow, x500_lidar_down, x500_lidar_front,
         advanced_plane, airspeed, gimbal, lawnmower, lidar_2d_v2,
         mono_cam, moving_platform, omnicopter, OakD-Lite, optical_flow,
         px4vision, quadtailsitter, r1_rover, rc_cessna,
         rover_differential, standard_vtol, tiltrotor