### PR TITLE
feat: add terrain world with sloped ridge

### DIFF
--- a/worlds/terrain.sdf
+++ b/worlds/terrain.sdf
@@ -1,0 +1,107 @@
+<sdf version='1.9'>
+  <world name='terrain'>
+    <physics type="ode">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>250</real_time_update_rate>
+    </physics>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <scene>
+      <ambient>0.8 0.5 1</ambient>
+      <grid>false</grid>
+      <sky>
+        <clouds>true</clouds>
+      </sky>
+      <shadows>1</shadows>
+    </scene>
+    <light name='sunUTC' type='directional'>
+      <pose>0 0 500 0 -0 0</pose>
+      <cast_shadows>false</cast_shadows>
+      <intensity>1</intensity>
+      <direction>0.001 0.625 -0.78</direction>
+      <diffuse>0.904 0.904 0.904 1</diffuse>
+      <specular>0.271 0.271 0.271 1</specular>
+      <attenuation>
+        <range>2000</range>
+        <linear>0</linear>
+        <constant>1</constant>
+        <quadratic>0</quadratic>
+      </attenuation>
+    </light>
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>1 1</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>500 500</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.7 0.7 0.7 1</ambient>
+            <diffuse>0.7 0.7 0.7 1</diffuse>
+            <specular>0.3 0.3 0.3 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <!--
+      Ridge running N-S, perpendicular to the eastward flight path.
+      Triangular cross-section (40 m base, 10 m apex => ~27 deg slope) extruded
+      80 m along Y so the drone crosses a continuously sloped surface.
+      The polyline is defined in the link's local XY plane and extruded along
+      local Z. We rotate the model with roll = +pi/2 so:
+        local +Y (apex direction) -> world +Z  (apex points up)
+        local +Z (extrusion)      -> world -Y
+      With pose y = 40 and height = 80, the ridge spans world y in [-40, 40].
+    -->
+    <model name="ridge">
+      <static>true</static>
+      <pose>40 20 0 1.5708 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <polyline>
+              <point>-20 0</point>
+              <point>20 0</point>
+              <point>0 10</point>
+              <height>40</height>
+            </polyline>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <polyline>
+              <point>-20 0</point>
+              <point>20 0</point>
+              <point>0 10</point>
+              <height>40</height>
+            </polyline>
+          </geometry>
+          <material>
+            <ambient>0.4 0.3 0.2 1</ambient>
+            <diffuse>0.5 0.4 0.3 1</diffuse>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+      <latitude_deg>47.397971057728974</latitude_deg>
+      <longitude_deg>8.546163739800146</longitude_deg>
+      <elevation>400</elevation>
+    </spherical_coordinates>
+  </world>
+</sdf>


### PR DESCRIPTION
New world `terrain.sdf` for testing terrain-relative auto navigation (MAV_FRAME_GLOBAL_TERRAIN_ALT_INT DO_REPOSITION). Pairs naturally with the gz_x500_lidar_down airframe.

<img width="1921" height="1059" alt="image" src="https://github.com/user-attachments/assets/a4a4d3e7-aae8-4fbc-998a-9a61761977be" />


Layout:
- 500x500 m visible flat ground at world z = 0
- A 40 m wide, 10 m tall, 40 m long triangular-prism ridge ~20 m east of the spawn (apex at world (40, 0, 10)). Continuously sloped (~27 deg) so the rangefinder reading varies smoothly as the vehicle crosses, avoiding spurious EKF terrain-estimate resets that vertical walls would trigger.
- Spherical coordinates anchored at (47.397971, 8.546164, 0) so home AMSL is 0 by default; raise the elevation to test against non-zero AMSL anchors.