### PR TITLE
feat(advanced_plane): add parachute plugin

### DIFF
--- a/models/advanced_plane/model.sdf
+++ b/models/advanced_plane/model.sdf
@@ -722,5 +722,10 @@
       <motorType>velocity</motorType>
 
     </plugin>
+    <plugin filename="ParachutePlugin" name="gz::sim::systems::ParachuteSystem">
+      <link_name>base_link</link_name>
+      <cd_a>0.64</cd_a>
+      <angular_damping>1.0</angular_damping>
+    </plugin>
   </model>
 </sdf>


### PR DESCRIPTION
Loads the PX4 ParachutePlugin gz system: the parachute deploys on the release message the PX4 gz bridge forwards on /model/<name>/parachute, then applies canopy drag and angular damping to base_link. CdA of 0.64 m^2 gives the 1 kg airframe a canopy sink rate of about 5 m/s.


Corresponding PX4 PR: https://github.com/PX4/PX4-Autopilot/pull/28044